### PR TITLE
find by link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-* Develop
-  solve problem with randomly failing spec
+* Version 1.1
+  Solve problem with randomly failing spec
+  Search for elements with 'href' or 'data-href' to find links
 
 * Version 1.0.1
   Rescueing Javascript errors

--- a/grell.gemspec
+++ b/grell.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'poltergeist', '~> 1.5'
 
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "byebug", "~> 3.5"
+  spec.add_development_dependency "byebug", "~> 4.0"
   spec.add_development_dependency "kender"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "webmock", '~> 1.18'

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -87,7 +87,7 @@ module Grell
     end
 
     def all_links
-      unique_links = @rawpage.all_anchors.map { |a| a[:href] }.uniq.compact
+      unique_links = @rawpage.all_anchors.map { |anchor| anchor[:href] }.uniq.compact
       unique_links.map { |link| link_to_url(link) }.compact
     rescue Capybara::Poltergeist::ObsoleteNode
       Log.warn "We found an obsolete node in #{@url}. Ignoring all links"

--- a/lib/grell/rawpage.rb
+++ b/lib/grell/rawpage.rb
@@ -20,8 +20,11 @@ module Grell
     end
 
     def all_anchors
-      all('a', visible: false)
+      # Some elements may not be "a" elements but still provide a link. This usually is done for Javascript
+      # to convert other elements which are not links to be able to be clicked naturally.
+      all('[href]', visible: false).to_a + all('[data-href]', visible: false).to_a
     end
+
 
     def host
       page.current_host

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.0.1"
+  VERSION = "1.1"
 end

--- a/spec/lib/page_spec.rb
+++ b/spec/lib/page_spec.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 RSpec.describe Grell::Page do
 
   let(:page_id) { rand(10).floor + 10}


### PR DESCRIPTION
Instead of looking for 'a' elements, we lookf for elements which have 'href' or 'data-href' attributes.
That shoudl help finding for instance table rows with these attributes but nto using the 'a' element.

@thoshikawa-mdsol 
