### PR TITLE
added autofollowing of redirects to grell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Version 1.5.0
+  Grell will follow redirects.
+  Added #followed_redirects? #error? #current_url methods to the Page class
+
 * Version 1.4.0
   Added crawler.restart to restart browser process
   The block of code can make grell retry any given page.

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -48,8 +48,24 @@ module Grell
       unavailable_page(404, e)
     end
 
+    # Number of times we have retried the current page
     def retries
       [@times_visited -1, 0].max
+    end
+
+    # The current URL, this may be different from the URL we asked for if there was some redirect
+    def current_url
+      @rawpage.current_url
+    end
+
+    # True if we followed a redirect to get the current contents
+    def followed_redirects?
+      current_url != @url
+    end
+
+    # True if there page responded with an error
+    def error?
+      !!(status.to_s =~ /[4|5]\d\d/)
     end
 
     private

--- a/lib/grell/rawpage.rb
+++ b/lib/grell/rawpage.rb
@@ -5,6 +5,7 @@ module Grell
 
     def navigate(url)
       visit(url)
+      follow_redirects!
     end
 
     def headers
@@ -32,6 +33,19 @@ module Grell
 
     def has_selector?(selector)
       page.has_selector?(selector)
+    end
+
+    private
+
+    def follow_redirects!
+      # Phantom is very weird, it will follow a redirect to provide the correct body but will not fill the
+      # status and the headers, if we are in that situation, revisit the page with the correct url this time.
+      # Note that we will still fail if we have more than 5 redirects on a row
+      redirects = 0
+      while(page.status_code == nil && redirects < 5)
+        visit( CGI.unescape(page.current_url))
+        redirects = redirects + 1
+      end
     end
   end
 end

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end


### PR DESCRIPTION
@thoshikawa-mdsol  Added autofollowing of redirects to Grell
Prior to this change, Grell provided the body but incorrect status and headers when following a redirect.
This was a very confusing, following the redirect makes it visit the page twice but solve those issues
