### PR TITLE
[Fix] Use non-deprecated wait time attribute

### DIFF
--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -22,7 +22,7 @@ module Grell
          })
       end
 
-      Capybara.default_wait_time = 3
+      Capybara.default_max_wait_time = 3
       Capybara.run_server = false
       Capybara.default_driver = :poltergeist_crawler
       page.driver.headers = {


### PR DESCRIPTION
### Before

```
.........................DEPRECATED: #default_wait_time= is deprecated, please use #default_max_wait_time= instead
.DEPRECATED: #default_wait_time= is deprecated, please use #default_max_wait_time= instead
..................................

Finished in 0.84408 seconds (files took 3.24 seconds to load)
60 examples, 0 failures
```
### After

```
............................................................

Finished in 0.78637 seconds (files took 3.27 seconds to load)
60 examples, 0 failures
```

@JordiPolo @thoshikawa-mdsol @jfeltesse-mdsol @cabbott @BPONTES 
