### PR TITLE
Clients can customize how URLs are compared when crawling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Version 1.5.2
+  Don't rescue Timeout error, so that Delayed Job can properly terminate hanging jobs
+
 * Version 1.5.1
   Fixed deprecation warning (Thanks scott)
   Updated Poltergeist dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,55 @@
-* Version 1.5.2
-  Don't rescue Timeout error, so that Delayed Job can properly terminate hanging jobs
+# 1.6
+  * Support custom URL comparison when adding new pages during crawling
+  * Don't rescue Timeout error, so that Delayed Job can properly terminate hanging jobs
+  * Fail early if Capybara doesn't initialize properly
 
-* Version 1.5.1
-  Fixed deprecation warning (Thanks scott)
-  Updated Poltergeist dependency
+# 1.5.1
+  * Fixed deprecation warning (Thanks scott)
+  * Updated Poltergeist dependency
 
-* Version 1.5.0
-  Grell will follow redirects.
-  Added #followed_redirects? #error? #current_url methods to the Page class
+# 1.5.0
+  * Grell will follow redirects.
+  * Added #followed_redirects? #error? #current_url methods to the Page class
 
-* Version 1.4.0
-  Added crawler.restart to restart browser process
-  The block of code can make grell retry any given page.
+# 1.4.0
+  * Added crawler.restart to restart browser process
+  * The block of code can make grell retry any given page.
 
-* Version 1.3.2
-  Rescue Timeout error and return an empty page when that happens
+# 1.3.2
+  * Rescue Timeout error and return an empty page when that happens
 
-* Version 1.3.1
-  Added whitelisting and blacklisting
-  Better info in gemspec
+# 1.3.1
+  * Added whitelisting and blacklisting
+  * Better info in gemspec
 
-* Version 1.3
-  The Crawler object allows you to provide an external logger object.
-  Clearer semantics when an error happens, special headers are returned so the user can inspect the error
+# 1.3
+  * The Crawler object allows you to provide an external logger object.
+  * Clearer semantics when an error happens, special headers are returned so the user can inspect the error
+  * Caveats:
+    - The 'debug' option in the crawler does not have any affect anymore. Provide an external logger with 'logger' instead
+    - The errors provided in the headers by grell has changed from 'grell_status' to 'grellStatus'.
+    - The 'visited' property in the page was never supposed to be accesible. Use 'visited?' instead.
 
-  Caveats:
-  - The 'debug' option in the crawler does not have any affect anymore. Provide an external logger with 'logger' instead
-  - The errors provided in the headers by grell has changed from 'grell_status' to 'grellStatus'.
-  - The 'visited' property in the page was never supposed to be accesible. Use 'visited?' instead.
+# 1.2.1
+  * Solve bug: URLs are case insensitive
 
-* Version 1.2.1
-  Solve bug: URLs are case insensitive
+# 1.2
+  * Grell now will consider two links to point to the same page only when the whole URL is exactly the same.
+    Versions previously would only consider two links to be the same when they shared the path.
 
-* Version 1.2
-  Grell now will consider two links to point to the same page only when the whole URL is exactly the same.
-  Versions previously would only consider two links to be the same when they shared the path.
+# 1.1.2
+  * Solve bug where we were adding links in heads as if there were normal links in the body
 
-* Version 1.1.2
-  Solve bug where we were adding links in heads as if there were normal links in the body
+# 1.1.1
+  * Solve bug with the new data-href functionality
 
-* Version 1.1.1
-  Solve bug with the new data-href functionality
+# 1.1
+  * Solve problem with randomly failing spec
+  * Search for elements with 'href' or 'data-href' to find links
 
-* Version 1.1
-  Solve problem with randomly failing spec
-  Search for elements with 'href' or 'data-href' to find links
+# 1.0.1
+  * Rescueing Javascript errors
 
-* Version 1.0.1
-  Rescueing Javascript errors
-
-* Version 1.0
-  Initial implementation
-  Basic support to crawling pages.
+# 1.0
+  * Initial implementation
+  * Basic support to crawling pages.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,26 @@ your are crawling. It will never follow links linking outside your site.
 If you want to further limit the amount of links crawled, you can use
 whitelisting, blacklisting or manual filtering.
 
+#### Custom URL Comparison
+By default, Grell will detect new URLs to visit by comparing the full URL
+with the URLs of the discovered and visited links. This functionality can
+be changed by passing a block of code to Grells `start_crawling` method.
+In the below example, the path of the URLs (instead of the full URL) will
+be compared.
+
+```ruby
+require 'grell'
+
+crawler = Grell::Crawler.new
+
+add_match_block = Proc.new do |collection_page, page|
+  collection_page.path == page.path
+end
+
+crawler.start_crawling('http://www.google.com', add_match_block: add_match_block) do |current_page|
+...
+end
+```
 
 #### Whitelisting
 

--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -30,7 +30,7 @@ module Grell
         "User-Agent" => USER_AGENT
       }
 
-      fail "Poltergeis Driver could not be properly initialized" unless @poltergeist_driver
+      fail "Poltergeist Driver could not be properly initialized" unless @poltergeist_driver
 
       @poltergeist_driver
     end

--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -29,6 +29,9 @@ module Grell
         "DNT" => 1,
         "User-Agent" => USER_AGENT
       }
+
+      fail "Poltergeis Driver could not be properly initialized" unless @poltergeist_driver
+
       @poltergeist_driver
     end
   end

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -44,8 +44,6 @@ module Grell
       unavailable_page(404, e)
     rescue Capybara::Poltergeist::StatusFailError => e
       unavailable_page(404, e)
-    rescue Timeout::Error => e #This error inherits from Interruption, do not inherit from StandardError
-      unavailable_page(404, e)
     end
 
     # Number of times we have retried the current page

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -66,6 +66,13 @@ module Grell
       !!(status.to_s =~ /[4|5]\d\d/)
     end
 
+    # Extracts the path (e.g. /actions/test_action) from the URL
+    def path
+      URI.parse(@url).path
+    rescue URI::InvalidURIError # Invalid URLs will be added and caught when we try to navigate to them
+      @url
+    end
+
     private
     def unavailable_page(status, exception)
       Grell.logger.warn "The page with the URL #{@url} was not available. Exception #{exception}"

--- a/lib/grell/page_collection.rb
+++ b/lib/grell/page_collection.rb
@@ -6,8 +6,11 @@ module Grell
   class PageCollection
     attr_reader :collection
 
-    def initialize
+    # A block containing the logic that determines if a new URL should be added
+    # to the collection or if it is already present will be passed to the initializer.
+    def initialize(add_match_block)
       @collection = []
+      @add_match_block = add_match_block
     end
 
     def create_page(url, parent_id)
@@ -39,8 +42,9 @@ module Grell
       # Although finding unique pages based on URL will add pages with different query parameters,
       # in some cases we do link to different pages depending on the query parameters like when using proxies
       new_url = @collection.none? do |collection_page|
-        collection_page.url.downcase == page.url.downcase
+        @add_match_block.call(collection_page, page)
       end
+
       if new_url
         @collection.push page
       end

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.5.1"
+  VERSION = "1.5.2"
 end

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.5.2"
+  VERSION = "1.6"
 end

--- a/spec/lib/page_collection_spec.rb
+++ b/spec/lib/page_collection_spec.rb
@@ -1,8 +1,14 @@
 
 RSpec.describe Grell::PageCollection do
-  let(:collection) {Grell::PageCollection.new}
-  let(:url) {'http://www.github.com/SomeUser/dragonlance?search=false'}
-  let(:url2) {'http://www.github.com/OtherUser/forgotten?search=false'}
+  let(:add_match_block) do
+    Proc.new do |collection_page, page|
+      collection_page.url.downcase == page.url.downcase
+    end
+  end
+
+  let(:collection) { Grell::PageCollection.new(add_match_block) }
+  let(:url) { 'http://www.github.com/SomeUser/dragonlance?search=false' }
+  let(:url2) { 'http://www.github.com/OtherUser/forgotten?search=false' }
 
   context 'empty collection' do
 
@@ -20,7 +26,8 @@ RSpec.describe Grell::PageCollection do
   end
 
   context 'one unvisited page' do
-    let(:page) {collection.create_page(url, 0)}
+    let(:page) { collection.create_page(url, 0) }
+
     before do
       allow(page).to receive(:visited?).and_return(false)
     end
@@ -40,7 +47,8 @@ RSpec.describe Grell::PageCollection do
   end
 
   context 'one visited page' do
-    let(:page) {collection.create_page(url, 0)}
+    let(:page) { collection.create_page(url, 0) }
+
     before do
       allow(page).to receive(:visited?).and_return(true)
     end
@@ -59,8 +67,9 @@ RSpec.describe Grell::PageCollection do
   end
 
   context 'one visited and one unvisited page with the same url' do
-    let(:page) {collection.create_page(url, 0)}
-    let(:unvisited)  {collection.create_page(url.upcase, 0)}
+    let(:page) { collection.create_page(url, 0) }
+    let(:unvisited) { collection.create_page(url.upcase, 0) }
+
     before do
       allow(page).to receive(:visited?).and_return(true)
       allow(unvisited).to receive(:visited?).and_return(false)
@@ -88,8 +97,9 @@ RSpec.describe Grell::PageCollection do
   end
 
   context 'one visited and one unvisited page with different URLs' do
-    let(:page) {collection.create_page(url, 0)}
-    let(:unvisited)  {collection.create_page(url2, 0)}
+    let(:page) { collection.create_page(url, 0) }
+    let(:unvisited) { collection.create_page(url2, 0) }
+
     before do
       allow(page).to receive(:visited?).and_return(true)
       allow(unvisited).to receive(:visited?).and_return(false)
@@ -109,9 +119,10 @@ RSpec.describe Grell::PageCollection do
   end
 
   context 'one visited and one unvisited page with different URLs only different by the query' do
-    let(:page) {collection.create_page(url, 0)}
-    let(:url3) {'http://www.github.com/SomeUser/dragonlance?search=true'}
-    let(:unvisited)  {collection.create_page(url3, 0)}
+    let(:page) { collection.create_page(url, 0) }
+    let(:url3) { 'http://www.github.com/SomeUser/dragonlance?search=true' }
+    let(:unvisited) { collection.create_page(url3, 0) }
+
     before do
       allow(page).to receive(:visited?).and_return(true)
       allow(unvisited).to receive(:visited?).and_return(false)
@@ -131,19 +142,18 @@ RSpec.describe Grell::PageCollection do
   end
 
   context 'several unvisited pages' do
-    let(:page) {collection.create_page(url, 2)}
-    let(:page2) {collection.create_page(url2, 0)}
+    let(:page) { collection.create_page(url, 2) }
+    let(:page2) { collection.create_page(url2, 0) }
+
     before do
       allow(page).to receive(:visited?).and_return(true)
       allow(page2).to receive(:visited?).and_return(false)
     end
 
-    it "returns the page which has an earlier parent" do
+    it 'returns the page which has an earlier parent' do
       expect(collection.next_page).to eq(page2)
     end
 
   end
-
-
 
 end

--- a/spec/lib/page_spec.rb
+++ b/spec/lib/page_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe Grell::Page do
     end
   end
 
-  [Capybara::Poltergeist::JavascriptError, Capybara::Poltergeist::BrowserError, URI::InvalidURIError,
-   Capybara::Poltergeist::TimeoutError, Capybara::Poltergeist::StatusFailError, Timeout::Error ].each do |error_type|
+  [ Capybara::Poltergeist::JavascriptError, Capybara::Poltergeist::BrowserError, URI::InvalidURIError,
+    Capybara::Poltergeist::TimeoutError, Capybara::Poltergeist::StatusFailError ].each do |error_type|
 
     context "#{error_type}" do
       let(:headers) do

--- a/spec/lib/page_spec.rb
+++ b/spec/lib/page_spec.rb
@@ -1,26 +1,31 @@
 RSpec.describe Grell::Page do
 
-  let(:page_id) { rand(10).floor + 10}
-  let(:parent_page_id) {rand(10).floor}
-  let(:page) {Grell::Page.new(url, page_id, parent_page_id)}
-  let(:host) {"http://www.example.com"}
-  let(:url) {"http://www.example.com/test"}
+  let(:page_id) { rand(10).floor + 10 }
+  let(:parent_page_id) { rand(10).floor }
+  let(:page) { Grell::Page.new(url, page_id, parent_page_id) }
+  let(:host) { 'http://www.example.com' }
+  let(:url) { 'http://www.example.com/test' }
   let(:returned_headers)  { { 'Other-Header' => 'yes', 'Content-Type' => 'text/html' }}
-  let(:now) {Time.now}
+  let(:now) { Time.now }
+
   before do
     allow(Time).to receive(:now).and_return(now)
-    Grell.logger = Logger.new(nil) #avoids noise in rspec output
+    Grell.logger = Logger.new(nil) # avoids noise in rspec output
   end
 
-  it "gives access to the url" do
+  it 'gives access to the url' do
     expect(page.url).to eq(url)
   end
 
-  it "gives access to the page id" do
+  it 'gives access to the path' do
+    expect(page.path).to eq('/test')
+  end
+
+  it 'gives access to the page id' do
     expect(page.id).to eq(page_id)
   end
 
-  it "gives access to the parent page id" do
+  it 'gives access to the parent page id' do
     expect(page.parent_id).to eq(parent_page_id)
   end
 
@@ -68,6 +73,7 @@ RSpec.describe Grell::Page do
         proxy.stub(url).and_return(body: '', code: 200, headers: {})
         page.navigate
       end
+
       it '#retries return 0' do
         expect(page.retries).to eq(0)
       end
@@ -79,6 +85,7 @@ RSpec.describe Grell::Page do
         page.navigate
         page.navigate
       end
+
       it '#retries return 1' do
         expect(page.retries).to eq(1)
       end
@@ -109,25 +116,27 @@ RSpec.describe Grell::Page do
           errorMessage: error_message
         }
       end
-      let(:error_message) {'Trusmis broke it again'}
-      let(:now) {Time.now}
+      let(:error_message) { 'Trusmis broke it again' }
+      let(:now) { Time.now }
+
       before do
         allow_any_instance_of(Grell::RawPage).to receive(:navigate).and_raise(error_type, 'error')
         allow_any_instance_of(error_type).to receive(:message).and_return(error_message)
         page.navigate
       end
+
       it_behaves_like 'an errored grell page'
     end
   end
 
 
   context 'we have not yet navigated to the page' do
-    let(:visited) {false}
-    let(:status) {nil}
-    let(:body) {''}
-    let(:links) {[]}
-    let(:expected_headers) {{}}
-    let(:now) {nil}
+    let(:visited) { false }
+    let(:status) { nil }
+    let(:body) { '' }
+    let(:links) { [] }
+    let(:expected_headers) { {} }
+    let(:now) { nil }
 
     before do
       proxy.stub(url).and_return(body: body, code: status, headers: returned_headers.dup)
@@ -138,11 +147,11 @@ RSpec.describe Grell::Page do
   end
 
   context 'navigating to the URL we get a 404' do
-    let(:visited) {true}
-    let(:status) { 404}
-    let(:body) {'<html><head></head><body>nothing cool</body></html>'}
-    let(:links) {[]}
-    let(:expected_headers) {returned_headers}
+    let(:visited) { true }
+    let(:status) { 404 }
+    let(:body) { '<html><head></head><body>nothing cool</body></html>' }
+    let(:links) { [] }
+    let(:expected_headers) { returned_headers }
 
     before do
       proxy.stub(url).and_return(body: body, code: status, headers: returned_headers.dup)
@@ -154,17 +163,19 @@ RSpec.describe Grell::Page do
   end
 
   context 'navigating to an URL with redirects, follows them transparently' do
-    let(:visited) {true}
-    let(:status) { 200}
-    let(:body) {'<html><head></head><body>nothing cool</body></html>'}
-    let(:links) {[]}
-    let(:expected_headers) {returned_headers}
-    let(:real_url) {'http://example.com/other'}
+    let(:visited) { true }
+    let(:status) { 200 }
+    let(:body) { '<html><head></head><body>nothing cool</body></html>' }
+    let(:links) { [] }
+    let(:expected_headers) { returned_headers }
+    let(:real_url) { 'http://example.com/other' }
+
     before do
       proxy.stub(url).and_return(:redirect_to => real_url)
       proxy.stub(real_url).and_return(body: body, code: status, headers: returned_headers.dup)
       page.navigate
     end
+
     it_behaves_like 'a grell page'
 
     it 'followed_redirects? is true' do
@@ -178,11 +189,11 @@ RSpec.describe Grell::Page do
 
   #Here also add examples that may happen for almost all pages (no errors, no redirects)
   context 'navigating to the URL we get page with no links' do
-    let(:visited) {true}
-    let(:status) { 200}
-    let(:body) {'<html><head></head><body>nothing cool</body></html>'}
-    let(:links) {[]}
-    let(:expected_headers) {returned_headers}
+    let(:visited) { true }
+    let(:status) { 200 }
+    let(:body) { '<html><head></head><body>nothing cool</body></html>' }
+    let(:links) { [] }
+    let(:expected_headers) { returned_headers }
 
     before do
       proxy.stub(url).and_return(body: body, code: status, headers: returned_headers.dup)
@@ -205,8 +216,8 @@ RSpec.describe Grell::Page do
   end
 
   context 'navigating to the URL we get page with links using a elements' do
-    let(:visited) {true}
-    let(:status) { 200}
+    let(:visited) { true }
+    let(:status) { 200 }
     let(:body) do
       "<html><head></head><body>
       Hello world!
@@ -215,8 +226,8 @@ RSpec.describe Grell::Page do
       <a href=\"http://www.outsidewebsite.com/help.html\">help</a>
       </body></html>"
     end
-    let(:links) {["http://www.example.com/trusmis.html", "http://www.example.com/help.html"]}
-    let(:expected_headers) {returned_headers}
+    let(:links) { ['http://www.example.com/trusmis.html', 'http://www.example.com/help.html'] }
+    let(:expected_headers) { returned_headers }
 
     before do
       proxy.stub(url).and_return(body: body, code: status, headers: returned_headers.dup)
@@ -231,8 +242,8 @@ RSpec.describe Grell::Page do
   end
 
   context 'navigating to the URL we get page with links with absolute links' do
-    let(:visited) {true}
-    let(:status) { 200}
+    let(:visited) { true }
+    let(:status) { 200 }
     let(:body) do
       "<html><head></head><body>
       Hello world!
@@ -241,8 +252,8 @@ RSpec.describe Grell::Page do
       <a href=\"http://www.outsidewebsite.com/help.html\">help</a>
       </body></html>"
     end
-    let(:links) {["http://www.example.com/trusmis.html", "http://www.example.com/help.html"]}
-    let(:expected_headers) {returned_headers}
+    let(:links) { ['http://www.example.com/trusmis.html', 'http://www.example.com/help.html'] }
+    let(:expected_headers) { returned_headers }
 
     before do
       proxy.stub(url).and_return(body: body, code: status, headers: returned_headers.dup)
@@ -257,8 +268,8 @@ RSpec.describe Grell::Page do
   end
 
   context 'navigating to the URL we get page with links using a mix of elements' do
-    let(:visited) {true}
-    let(:status) { 200}
+    let(:visited) { true }
+    let(:status) { 200 }
     let(:body) do
       "<html><head></head><body>
       Hello world!
@@ -274,11 +285,10 @@ RSpec.describe Grell::Page do
       </body></html>"
     end
     let(:links) do
-      ["http://www.example.com/trusmis.html", "http://www.example.com/help.html",
-       'http://www.example.com/more_help.html', 'http://www.example.com/help_me.html'
-      ]
+      [ 'http://www.example.com/trusmis.html', 'http://www.example.com/help.html',
+        'http://www.example.com/more_help.html', 'http://www.example.com/help_me.html' ]
     end
-    let(:expected_headers) {returned_headers}
+    let(:expected_headers) { returned_headers }
 
     before do
       proxy.stub(url).and_return(body: body, code: status, headers: returned_headers.dup)
@@ -287,16 +297,36 @@ RSpec.describe Grell::Page do
 
     it_behaves_like 'a grell page'
 
+    describe '#path' do
+      context 'proper url' do
+        let(:url) { 'http://www.anyurl.com/path' }
+        let(:page) { Grell::Page.new(url, page_id, parent_page_id) }
+
+        it 'returns the path' do
+          expect(page.path).to eq('/path')
+        end
+      end
+
+      context 'broken url' do
+        let(:url) { 'www.an.asda.fasfasf.yurl.com/path' }
+        let(:page) { Grell::Page.new(url, page_id, parent_page_id) }
+
+        it 'returns the path' do
+          expect(page.path).to eq(url)
+        end
+      end
+    end
+
     it 'do not return links to external websites' do
       expect(page.links).to_not include('http://www.outsidewebsite.com/help.html')
     end
   end
 
  context 'navigating to the URL we get page with links inside the header section of the code' do
-    let(:visited) {true}
-    let(:status) { 200}
-    let(:css) {'/application.css'}
-    let(:favicon) {'/favicon.ico'}
+    let(:visited) { true }
+    let(:status) { 200 }
+    let(:css) { '/application.css' }
+    let(:favicon) { '/favicon.ico' }
     let(:body) do
       "<html><head>
       <title>mimi</title>
@@ -309,9 +339,9 @@ RSpec.describe Grell::Page do
       </body></html>"
     end
     let(:links) do
-      ["http://www.example.com/trusmis.html"]
+      ['http://www.example.com/trusmis.html']
     end
-    let(:expected_headers) {returned_headers}
+    let(:expected_headers) { returned_headers }
 
     before do
       proxy.stub(url).and_return(body: body, code: status, headers: returned_headers.dup)
@@ -338,11 +368,12 @@ RSpec.describe Grell::Page do
       proxy.stub(url).and_return(body: body, code: nil, headers: {})
       page.navigate
     end
-    let(:visited) {true}
-    let(:status) { nil}
-    let(:body) {''}
-    let(:links) {[]}
-    let(:expected_headers) {{}}
+
+    let(:visited) { true }
+    let(:status) { nil }
+    let(:body) { '' }
+    let(:links) { [] }
+    let(:expected_headers) { {} }
 
     it_behaves_like 'a grell page'
   end


### PR DESCRIPTION
A couple things being added:
- Allow Grell users the ability to customize how pages are compared when determining if they should be added to the page collection (i.e. pages to be visited)
- Fail early when the Poltergeist Driver doesn't initialize properly
- Bringing back the `path` method for Page (see https://github.com/mdsol/grell/commit/064537a048ee6c41767c2721cc69899ca5cd61c3#diff-13eb803ebaca339d41368fbd4f7bb9d2)
- Minor whitespace changes for code styling purposes

@mdsol/team-10 
