### PR TITLE
[Feature] Non-static Capybara driver name / Store redirect URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.1
+  * Use non-static name to support registering Poltergeist crawler multiple times
+  * More exception handling, store redirected URLs in addition to original URL
+
 # 1.6
   * Support custom URL comparison when adding new pages during crawling
   * Don't rescue Timeout error, so that Delayed Job can properly terminate hanging jobs

--- a/grell.gemspec
+++ b/grell.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", '~> 1.18'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'puffing-billy', '~> 0.5'
+  spec.add_development_dependency 'timecop', '~> 0.8'
 end

--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -14,7 +14,9 @@ module Grell
     def setup_capybara
       @poltergeist_driver = nil
 
-      driver_name = "poltergeist_crawler_#{Time.now.strftime('%m_%d_%y_%H_%M')}".to_sym
+      # Capybara will not re-run the block if the driver name already exists, so the driver name
+      # will have a time integer appended to ensure uniqueness.
+      driver_name = "poltergeist_crawler_#{Time.now.to_i}".to_sym
       Capybara.register_driver driver_name do |app|
         @poltergeist_driver = Capybara::Poltergeist::Driver.new(app, {
           js_errors: false,
@@ -32,7 +34,7 @@ module Grell
         "User-Agent" => USER_AGENT
       }
 
-      fail "Poltergeist Driver could not be properly initialized" unless @poltergeist_driver
+      raise "Poltergeist Driver could not be properly initialized" unless @poltergeist_driver
 
       @poltergeist_driver
     end

--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -13,7 +13,9 @@ module Grell
 
     def setup_capybara
       @poltergeist_driver = nil
-      Capybara.register_driver :poltergeist_crawler do |app|
+
+      driver_name = "poltergeist_crawler_#{Time.now.strftime('%m_%d_%y_%H_%M')}".to_sym
+      Capybara.register_driver driver_name do |app|
         @poltergeist_driver = Capybara::Poltergeist::Driver.new(app, {
           js_errors: false,
           inspector: false,
@@ -24,7 +26,7 @@ module Grell
 
       Capybara.default_max_wait_time = 3
       Capybara.run_server = false
-      Capybara.default_driver = :poltergeist_crawler
+      Capybara.default_driver = driver_name
       page.driver.headers = {
         "DNT" => 1,
         "User-Agent" => USER_AGENT

--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -17,6 +17,8 @@ module Grell
       # Capybara will not re-run the block if the driver name already exists, so the driver name
       # will have a time integer appended to ensure uniqueness.
       driver_name = "poltergeist_crawler_#{Time.now.to_i}".to_sym
+      Grell.logger.info "GRELL Registering poltergeist driver with name '#{driver_name}'"
+
       Capybara.register_driver driver_name do |app|
         @poltergeist_driver = Capybara::Poltergeist::Driver.new(app, {
           js_errors: false,
@@ -34,7 +36,7 @@ module Grell
         "User-Agent" => USER_AGENT
       }
 
-      raise "Poltergeist Driver could not be properly initialized" unless @poltergeist_driver
+      raise 'Poltergeist Driver could not be properly initialized' unless @poltergeist_driver
 
       @poltergeist_driver
     end

--- a/lib/grell/crawler.rb
+++ b/lib/grell/crawler.rb
@@ -8,13 +8,13 @@ module Grell
     # Creates a crawler
     # options allows :logger to point to an object with the same interface than Logger in the standard library
     def initialize(options = {})
-      @driver = CapybaraDriver.setup(options)
-
       if options[:logger]
         Grell.logger = options[:logger]
       else
         Grell.logger = Logger.new(STDOUT)
       end
+
+      @driver = CapybaraDriver.setup(options)
     end
 
     # Restarts the PhantomJS process without modifying the state of visited and discovered pages.
@@ -63,7 +63,7 @@ module Grell
           end
         rescue Capybara::Poltergeist::BrowserError, Capybara::Poltergeist::DeadClient,
                Capybara::Poltergeist::JavascriptError, Capybara::Poltergeist::StatusFailError,
-               Capybara::Poltergeist::TimeoutError, Errno::ECONNRESET, Timeout::Error, URI::InvalidURIError => e
+               Capybara::Poltergeist::TimeoutError, Errno::ECONNRESET, URI::InvalidURIError => e
           site.unavailable_page(404, e)
           return
         end

--- a/lib/grell/crawler.rb
+++ b/lib/grell/crawler.rb
@@ -51,12 +51,21 @@ module Grell
       Grell.logger.info "Visiting #{site.url}, visited_links: #{@collection.visited_pages.size}, discovered #{@collection.discovered_pages.size}"
       site.navigate
       filter!(site.links)
+      add_redirect_url(site)
 
-      if block #The user of this block can send us a :retry to retry accessing the page
-        while block.call(site) == :retry
-          Grell.logger.info "Retrying our visit to #{site.url}"
-          site.navigate
-          filter!(site.links)
+      if block # The user of this block can send us a :retry to retry accessing the page
+        begin
+          while block.call(site) == :retry
+            Grell.logger.info "Retrying our visit to #{site.url}"
+            site.navigate
+            filter!(site.links)
+            add_redirect_url(site)
+          end
+        rescue Capybara::Poltergeist::BrowserError, Capybara::Poltergeist::DeadClient,
+               Capybara::Poltergeist::JavascriptError, Capybara::Poltergeist::StatusFailError,
+               Capybara::Poltergeist::TimeoutError, Errno::ECONNRESET, Timeout::Error, URI::InvalidURIError => e
+          site.unavailable_page(404, e)
+          return
         end
       end
 
@@ -77,6 +86,13 @@ module Grell
     def default_add_match
       Proc.new do |collection_page, page|
         collection_page.url.downcase == page.url.downcase
+      end
+    end
+
+    # Store the resulting redirected URL along with the original URL
+    def add_redirect_url(site)
+      if site.url != site.current_url
+        @collection.create_page(site.current_url, site.id)
       end
     end
 

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -36,7 +36,7 @@ module Grell
       @times_visited += 1
     rescue Capybara::Poltergeist::BrowserError, Capybara::Poltergeist::DeadClient,
            Capybara::Poltergeist::JavascriptError, Capybara::Poltergeist::StatusFailError,
-           Capybara::Poltergeist::TimeoutError, Errno::ECONNRESET, Timeout::Error, URI::InvalidURIError => e
+           Capybara::Poltergeist::TimeoutError, Errno::ECONNRESET, URI::InvalidURIError => e
       unavailable_page(404, e)
     end
 

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -34,15 +34,9 @@ module Grell
       @result_page = VisitedPage.new(@rawpage)
       @timestamp = Time.now
       @times_visited += 1
-    rescue Capybara::Poltergeist::JavascriptError => e
-      unavailable_page(404, e)
-    rescue Capybara::Poltergeist::BrowserError => e #This may happen internally on Poltergeist, they claim is a bug.
-      unavailable_page(404, e)
-    rescue URI::InvalidURIError => e #No cool URL means we report error
-      unavailable_page(404, e)
-    rescue Capybara::Poltergeist::TimeoutError => e #Poltergeist has its own timeout which is similar to Chromes.
-      unavailable_page(404, e)
-    rescue Capybara::Poltergeist::StatusFailError => e
+    rescue Capybara::Poltergeist::BrowserError, Capybara::Poltergeist::DeadClient,
+           Capybara::Poltergeist::JavascriptError, Capybara::Poltergeist::StatusFailError,
+           Capybara::Poltergeist::TimeoutError, Errno::ECONNRESET, Timeout::Error, URI::InvalidURIError => e
       unavailable_page(404, e)
     end
 
@@ -73,12 +67,13 @@ module Grell
       @url
     end
 
-    private
     def unavailable_page(status, exception)
       Grell.logger.warn "The page with the URL #{@url} was not available. Exception #{exception}"
       @result_page = ErroredPage.new(status, exception)
       @timestamp = Time.now
     end
+
+    private
 
     # Private class.
     # This is a result page when it has not been visited yet. Essentially empty of information

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.6"
+  VERSION = "1.6.1"
 end

--- a/spec/lib/capybara_driver_spec.rb
+++ b/spec/lib/capybara_driver_spec.rb
@@ -1,0 +1,32 @@
+
+RSpec.describe Grell::CapybaraDriver do
+  let(:ts) { Time.now }
+
+  describe 'setup_capybara' do
+    it 'properly registers the poltergeist driver' do
+      Timecop.freeze(ts)
+      driver = Grell::CapybaraDriver.new.setup_capybara
+      expect(driver).to be_instance_of(Capybara::Poltergeist::Driver)
+    end
+
+    it 'raises an exception if the driver cannot be initialized' do
+      Timecop.freeze(ts + 60)
+
+      # Attempt to register twice with the same driver name
+      Grell::CapybaraDriver.new.setup_capybara
+      expect { Grell::CapybaraDriver.new.setup_capybara }.
+        to raise_error "Poltergeist Driver could not be properly initialized"
+    end
+
+    it 'can register the poltergeist driver multiple times in a row' do
+      Timecop.freeze(ts + 120)
+      driver = Grell::CapybaraDriver.new.setup_capybara
+      expect(driver).to be_instance_of(Capybara::Poltergeist::Driver)
+    end
+
+    after do
+      Timecop.return
+    end
+  end
+
+end

--- a/spec/lib/crawler_spec.rb
+++ b/spec/lib/crawler_spec.rb
@@ -36,11 +36,16 @@ RSpec.describe Grell::Crawler do
 
     it 'yields the result if a block is given' do
       result = []
-      block = Proc.new {|n| result.push(n) }
+      block = Proc.new { |n| result.push(n) }
       crawler.crawl(page, block)
       expect(result.size).to eq(1)
       expect(result.first.url).to eq(url)
       expect(result.first.visited?).to eq(true)
+    end
+
+    it 'rescues any specified exceptions raised during the block execution' do
+      block = Proc.new { |n| raise Capybara::Poltergeist::BrowserError, 'Exception' }
+      expect{ crawler.crawl(page, block) }.to_not raise_error
     end
 
     it 'logs interesting information' do
@@ -61,6 +66,13 @@ RSpec.describe Grell::Crawler do
       crawler.crawl(page, block)
       expect(counter).to eq(times_retrying)
     end
+
+    it 'handles redirects by adding the current_url to the page collection' do
+      redirect_url = 'http://www.example.com/test/landing_page'
+      allow(page).to receive(:current_url).and_return(redirect_url)
+      expect_any_instance_of(Grell::PageCollection).to receive(:create_page).with(redirect_url, page_id)
+      crawler.crawl(page, nil)
+    end
   end
 
   context '#start_crawling' do
@@ -80,7 +92,7 @@ RSpec.describe Grell::Crawler do
 
     it 'calls the block we used to start_crawling' do
       result = []
-      block = Proc.new {|n| result.push(n) }
+      block = Proc.new { |n| result.push(n) }
       crawler.start_crawling(url, &block)
       expect(result.size).to eq(2)
       expect(result[0].url).to eq(url)

--- a/spec/lib/crawler_spec.rb
+++ b/spec/lib/crawler_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Grell::Crawler do
     it 'rescues any specified exceptions raised during the block execution' do
       block = Proc.new { |n| raise Capybara::Poltergeist::BrowserError, 'Exception' }
       expect{ crawler.crawl(page, block) }.to_not raise_error
+      expect(page.status).to eq(404)
     end
 
     it 'logs interesting information' do

--- a/spec/lib/page_spec.rb
+++ b/spec/lib/page_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe Grell::Page do
   end
 
   [ Capybara::Poltergeist::JavascriptError, Capybara::Poltergeist::BrowserError, URI::InvalidURIError,
-    Capybara::Poltergeist::TimeoutError, Capybara::Poltergeist::StatusFailError ].each do |error_type|
+    Capybara::Poltergeist::TimeoutError, Capybara::Poltergeist::StatusFailError,
+    Capybara::Poltergeist::DeadClient, Errno::ECONNRESET ].each do |error_type|
 
     context "#{error_type}" do
       let(:headers) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'grell'
 require 'byebug'
+require 'timecop'
 require 'webmock/rspec'
 require 'billy/rspec'
 require 'rack'


### PR DESCRIPTION
A couple small features / bug fixes
- Use non-static name to support registering Poltergeist crawler multiple times. Previously, the `register_driver` block would only run once. Since the name was already registered, it would not run the block and as a result, `@poltergeist_driver` would not be properly initialized.
- Store redirected URLs in addition to original URL (If the crawler was redirected, the final destination URL would not be stored and it was possible that the crawler would hit it again)
- More exception handling to cover a few more cases

@jcarres-mdsol @jfeltesse-mdsol @ykitamura-mdsol 
