### PR TITLE
[Fix] Reset Capybara drivers to Puffing Billy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Next Release
+  * Reset Capybara driver to Puffing Billy (used to rewrite URL requests in specs)
+
 # 1.6.1
   * Use non-static name to support registering Poltergeist crawler multiple times
   * More exception handling, store redirected URLs in addition to original URL

--- a/spec/lib/capybara_driver_spec.rb
+++ b/spec/lib/capybara_driver_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Grell::CapybaraDriver do
 
     after do
       Timecop.return
+
+      # Reset Capybara so future tests can easily stub HTTP requests
+      Capybara.javascript_driver = :poltergeist_billy
+      Capybara.default_driver = :poltergeist_billy
     end
   end
 


### PR DESCRIPTION
The Puffing Billy gem is used to rewrite URLs in other specs. Previously, the Capybara driver spec would change the Capybara driver and as a result, the URL rewriting would not occur.

Previously missed this issue due to Rspec running the specs in a random order (https://github.com/mdsol/grell/blob/develop/spec/spec_helper.rb#L56). Turns out I just got "lucky" and the specs executed the Capybara_driver_spec last, so that the other specs did not fail. After changing the run order to run the Capybara spec first, the build consistently failed. This change will prevent that.

@jcarres-mdsol @jfeltesse-mdsol @mdsol/team-10 
