### PR TITLE
[MCC-213727] Changed timestamp used for driver name from int to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.2
+  * Use float timestamp for Poltergeist driver name to support fast test executions
+  * Reset Capybara driver to Puffing Billy (used to rewrite URL requests in specs)
+
 # 1.6.1
   * Use non-static name to support registering Poltergeist crawler multiple times
   * More exception handling, store redirected URLs in addition to original URL

--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -16,7 +16,7 @@ module Grell
 
       # Capybara will not re-run the block if the driver name already exists, so the driver name
       # will have a time integer appended to ensure uniqueness.
-      driver_name = "poltergeist_crawler_#{Time.now.to_i}".to_sym
+      driver_name = "poltergeist_crawler_#{Time.now.to_f}".to_sym
       Grell.logger.info "GRELL Registering poltergeist driver with name '#{driver_name}'"
 
       Capybara.register_driver driver_name do |app|

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.6.1"
+  VERSION = "1.6.2"
 end


### PR DESCRIPTION
This PR solves the issue of Roper, which fails in Travis CI rspec.

Grell will not initialize with the same name of Poltergeist Driver(see the comment in the code right before the changed line), so we need smaller number of timestamps to have driver initialized explicitly under the super fast infrastructure such as in CI test.

@jcarres-mdsol @mdsol/team-10 
