### PR TITLE
fixed spec fails with 'bundle exec rspec --seed 28970'

### DIFF
--- a/spec/lib/crawler_spec.rb
+++ b/spec/lib/crawler_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Grell::Crawler do
     it 'can provide your own logger' do
       Grell::Crawler.new(external_driver: true, logger: 33)
       expect(Grell.logger).to eq(33)
+      Grell.logger = Logger.new(nil)
     end
 
     it 'provides a stdout logger if nothing provided' do


### PR DESCRIPTION
This PR solves the spec fail at specific run order which happened on [Travis](https://travis-ci.org/mdsol/grell/jobs/112771389).
You can verify this fix by `bundle exec rspec --seed 28970`.

@jcarres-mdsol 
