### PR TITLE
[MCC-223004] Add #quit to Capybara driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.4
+  * Added #quit to Capybara driver
+
 # 1.6.3
   * Only follow visible links
 

--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -40,6 +40,10 @@ module Grell
 
       @poltergeist_driver
     end
+
+    def quit
+      @poltergeist_driver.quit
+    end
   end
 
 end

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.6.3".freeze
+  VERSION = "1.6.4".freeze
 end

--- a/spec/lib/capybara_driver_spec.rb
+++ b/spec/lib/capybara_driver_spec.rb
@@ -23,14 +23,21 @@ RSpec.describe Grell::CapybaraDriver do
       driver = Grell::CapybaraDriver.new.setup_capybara
       expect(driver).to be_instance_of(Capybara::Poltergeist::Driver)
     end
+  end
 
-    after do
-      Timecop.return
-
-      # Reset Capybara so future tests can easily stub HTTP requests
-      Capybara.javascript_driver = :poltergeist_billy
-      Capybara.default_driver = :poltergeist_billy
+  describe 'quit' do
+    let(:driver) { Grell::CapybaraDriver.new.setup_capybara }
+    it 'quits the poltergeist driver' do
+      expect_any_instance_of(Capybara::Poltergeist::Driver).to receive(:quit)
+      driver.quit
     end
   end
 
+  after do
+    Timecop.return
+
+    # Reset Capybara so future tests can easily stub HTTP requests
+    Capybara.javascript_driver = :poltergeist_billy
+    Capybara.default_driver = :poltergeist_billy
+  end
 end


### PR DESCRIPTION
To avoid memory leak problem, `session.driver.quit` has to be called when we don't need session anymore

https://github.com/teampoltergeist/poltergeist#memory-leak

@mdsol/team-10 please review
