### PR TITLE
[MCC-228333] Updated phantomjs_logger not to open '/dev/null'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.6
+  * Updated phantomjs_logger not to open '/dev/null'
+
 # 1.6.5
   * Added #quit to Crawler
 

--- a/lib/grell/capybara_driver.rb
+++ b/lib/grell/capybara_driver.rb
@@ -23,7 +23,7 @@ module Grell
         @poltergeist_driver = Capybara::Poltergeist::Driver.new(app, {
           js_errors: false,
           inspector: false,
-          phantomjs_logger: open('/dev/null'),
+          phantomjs_logger: FakePoltergeistLogger,
           phantomjs_options: ['--debug=no', '--load-images=no', '--ignore-ssl-errors=yes', '--ssl-protocol=TLSv1']
          })
       end
@@ -43,6 +43,11 @@ module Grell
 
     def quit
       @poltergeist_driver.quit
+    end
+
+    module FakePoltergeistLogger
+      def self.puts(*)
+      end
     end
   end
 

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.6.5".freeze
+  VERSION = "1.6.6".freeze
 end


### PR DESCRIPTION
Roper stopped after ten days from deployment with the exception, 'too many open files'.
Looking up processes (lsof), the delayed job process opened so many '/dev/null's and hit the limit (1024):

```
 :
ruby      132598             roper 1006r      CHR                1,3      0t0       5430 /dev/null
ruby      132598             roper 1007r      CHR                1,3      0t0       5430 /dev/null
ruby      132598             roper 1008r      CHR                1,3      0t0       5430 /dev/null
ruby      132598             roper 1009r      CHR                1,3      0t0       5430 /dev/null
ruby      132598             roper 1010r      CHR                1,3      0t0       5430 /dev/null
 :
```

The poltergeist driver uses `open('/dev/null')` as logger, and it seems to remain open even after quitting the driver.
Roper job sleeps for ten minutes, it means the job runs about six times an hour, 100 times a day, and around ten days it will run more than 1000 times.

Getting an idea from the following page, updated `phantomjs_logger` not to open '/dev/null'.
https://www.reddit.com/r/ruby/comments/24zvvd/disabling_logging_in_poltergeist/

Running for two hours, '/dev/null' is not increasing, so far.

@mdsol/team-10 please review
