### PR TITLE
Increment '@times_visited' first to avoid infinite retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.7
+  * Increment '@times_visited' first to avoid infinite retries when rescuing errors
+
 # 1.6.6
   * Updated phantomjs_logger not to open '/dev/null'
 

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -33,11 +33,12 @@ module Grell
       end
       @result_page = VisitedPage.new(@rawpage)
       @timestamp = Time.now
-      @times_visited += 1
     rescue Capybara::Poltergeist::BrowserError, Capybara::Poltergeist::DeadClient,
            Capybara::Poltergeist::JavascriptError, Capybara::Poltergeist::StatusFailError,
            Capybara::Poltergeist::TimeoutError, Errno::ECONNRESET, URI::InvalidURIError => e
       unavailable_page(404, e)
+    ensure
+      @times_visited += 1
     end
 
     # Number of times we have retried the current page

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.6.6".freeze
+  VERSION = "1.6.7".freeze
 end

--- a/spec/lib/page_spec.rb
+++ b/spec/lib/page_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Grell::Page do
       expect(page).to be_visited
       expect(page.timestamp).to eq(now)
       expect(page.error?).to eq(true)
+      expect(page.instance_variable_get(:@times_visited)).to eq(1)
     end
   end
 


### PR DESCRIPTION
When Roper finds a wrong URL such as 'http://innovate.example.com/' (`http` instead of `https`) and tries to access it, Capybara returns `Capybara::Poltergeist::StatusFailError`, and at the point Grell is not counting up `@times_visited` and it makes infinite retrying to access the URL.

This PR will change to increment `@times_visited` first so that Roper can give up retrying.

@mdsol/team-10 
