### PR TITLE
avoids following disabled links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.8
+  * Avoid following disabled links
+
 # 1.6.7
   * Increment '@times_visited' first to avoid infinite retries when rescuing errors
 

--- a/grell.gemspec
+++ b/grell.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency 'capybara', '~> 2.7'
-  spec.add_dependency 'poltergeist', '~> 1.9'
+  spec.add_dependency 'poltergeist', '~> 1.10'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "byebug", "~> 4.0"

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -206,9 +206,12 @@ module Grell
       private
       def all_links
         # <link> can only be used in the <head> as of: https://developer.mozilla.org/en/docs/Web/HTML/Element/link
-        anchors_in_body = @rawpage.all_anchors.reject{|anchor| anchor.tag_name == 'link' }
+        anchors_in_body = @rawpage.all_anchors.reject { |anchor| anchor.tag_name == 'link' }
 
-        unique_links = anchors_in_body.map do |anchor|
+        # Do not follow disabled links
+        enabled_links = anchors_in_body.reject { |anchor| anchor.disabled? }
+
+        unique_links = enabled_links.map do |anchor|
          anchor['href'] || anchor['data-href']
         end.compact
 

--- a/lib/grell/version.rb
+++ b/lib/grell/version.rb
@@ -1,3 +1,3 @@
 module Grell
-  VERSION = "1.6.7".freeze
+  VERSION = "1.6.8".freeze
 end

--- a/spec/lib/page_spec.rb
+++ b/spec/lib/page_spec.rb
@@ -243,6 +243,29 @@ RSpec.describe Grell::Page do
     end
   end
 
+
+  context 'navigating to the URL we get page with disabled links' do
+    let(:visited) { true }
+    let(:status) { 200 }
+    let(:body) do
+      "<html><head></head><body>
+      Hello world!
+      <a href=\"/trusmis.html\">trusmis</a>
+      <a href=\"/help.html\">help</a>
+      <a href=\"javascript: void(0)\">help</a>
+      </body></html>"
+    end
+    let(:links) { ['http://www.example.com/trusmis.html', 'http://www.example.com/help.html'] }
+    let(:expected_headers) { returned_headers }
+
+    before do
+      proxy.stub(url).and_return(body: body, code: status, headers: returned_headers.dup)
+      page.navigate
+    end
+
+    it_behaves_like 'a grell page'
+  end
+
   context 'navigating to the URL we get page with links with absolute links' do
     let(:visited) { true }
     let(:status) { 200 }


### PR DESCRIPTION
It will be a bug if the crawler tries to follow a link that has been disabled with Javascript.

@mdsol/team-10 
