### PR TITLE
[MCC-228354] Reject javascript href elements, add missing capybara dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,9 @@ rvm:
   - 2.2.4
   - 2.3.0
 script: bundle exec rspec
+
+before_install:
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 Grell uses PhantomJS, you will need to download and install it in your
 system. Check for instructions in http://phantomjs.org/
-Grell has been tested with PhantomJS v1.9.x
+Grell has been tested with PhantomJS v2.1.x
 
 ## Usage
 

--- a/grell.gemspec
+++ b/grell.gemspec
@@ -24,12 +24,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'capybara', '~> 2.7'
   spec.add_dependency 'poltergeist', '~> 1.10'
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "byebug", "~> 4.0"
-  spec.add_development_dependency "kender", '~> 0.2'
-  spec.add_development_dependency "rake", '~> 10.0'
-  spec.add_development_dependency "webmock", '~> 1.18'
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'byebug', '~> 4.0'
+  spec.add_development_dependency 'kender', '~> 0.2'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'webmock', '~> 1.18'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'puffing-billy', '~> 0.5'
   spec.add_development_dependency 'timecop', '~> 0.8'
+  spec.add_development_dependency 'capybara-webkit', '~> 1.11.1'
+  spec.add_development_dependency 'selenium-webdriver', '~> 2.53.4'
 end

--- a/lib/grell/page.rb
+++ b/lib/grell/page.rb
@@ -206,7 +206,7 @@ module Grell
       private
       def all_links
         links =  @rawpage.all_anchors.map { |anchor| Link.new(anchor) }
-        body_enabled_links = links.reject { |link| link.inside_header? || link.disabled? }
+        body_enabled_links = links.reject { |link| link.inside_header? || link.disabled? || link.js_href? }
         body_enabled_links.map { |link| link.to_url(host) }.uniq.compact
 
       rescue Capybara::Poltergeist::ObsoleteNode
@@ -230,6 +230,11 @@ module Grell
         # Is the link disabled by either Javascript or CSS?
         def disabled?
           @anchor.disabled? || !!@anchor.native.attributes['disabled']
+        end
+
+        # Does the href use javascript?
+        def js_href?
+          href.start_with?('javascript:')
         end
 
         # Some links may use data-href + javascript to do interesting things

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'grell'
 require 'byebug'
 require 'timecop'
 require 'webmock/rspec'
-require 'billy/rspec'
+require 'billy/capybara/rspec'
 require 'rack'
 require 'rack/server'
 


### PR DESCRIPTION
Fixed the previously failing Travis builds. I added the `capybara-webkit` and `selenium-webdriver` dependencies. Also, I added an additional check to the `reject` block that removes `javascript: void(0)` href URLs (the https://github.com/mdsol/grell/blob/develop/spec/lib/page_spec.rb#L247 spec was failing previously.. @jcarres-mdsol any idea how this was passing before?). Lastly, I updated the travis config file, so that Travis installs PhantomJS 2.1.1 before running the specs.

See the failed jobs below:
- https://travis-ci.org/mdsol/grell/jobs/112779896
- https://travis-ci.org/mdsol/grell/jobs/147152121
- https://travis-ci.org/mdsol/grell/jobs/147353143

@mdsol/team-10 
